### PR TITLE
Filter out embeds in messageUpdate.

### DIFF
--- a/src/events/messageUpdate.js
+++ b/src/events/messageUpdate.js
@@ -19,7 +19,7 @@ client.on('messageUpdate', (oldMessage, newMessage) => {
             dbGuild.autoMod.mention ? await AutoModerationService.antiMentionSpamMsg(newMessage) : null;
 
             if (dbGuild.logMessages) {
-                if (newMessage.type === 'DEFAULT') {
+                if (newMessage.type === 'DEFAULT' && oldMessage.content !== newMessage.content) {
                     const logChannel = newMessage.guild.channels.get(dbGuild.channels.messageLog);
 
                     if (logChannel !== undefined) {


### PR DESCRIPTION
Filter out the messageUpdate calls when a message is embedded for edit logging.