### PR TITLE
Fix syntax error for getting GuildMember object from message

### DIFF
--- a/src/preconditions/command/groups/GuildOwner.js
+++ b/src/preconditions/command/groups/GuildOwner.js
@@ -9,7 +9,7 @@ class GuildOwner extends patron.Precondition {
     }
 
     async run(command, msg) {
-        if (ModerationService.getPermLevel(msg.dbGuild, msg.guild.member(msg.author)) === 3) {
+        if (ModerationService.getPermLevel(msg.dbGuild, msg.member) === 3) {
             return patron.PreconditionResult.fromSuccess();
         }
 

--- a/src/preconditions/command/groups/Moderator.js
+++ b/src/preconditions/command/groups/Moderator.js
@@ -9,7 +9,7 @@ class Moderator extends patron.Precondition {
     }
 
     async run(command, msg) {
-        if (ModerationService.getPermLevel(msg.dbGuild, msg.guild.member(msg.author)) >= 1) {
+        if (ModerationService.getPermLevel(msg.dbGuild, msg.member) >= 1) {
             return patron.PreconditionResult.fromSuccess();
         }
 


### PR DESCRIPTION
Fix syntax error for getting GuildMember object from message.